### PR TITLE
Add archive notice to fluvio-smartstream-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Fluvio SmartStreams
 
+> **NOTE**: This project has been relocated to [`fluvio-smartmodule-template`][1]. This
+> repository has been archived so that `cargo-generate` will still work with old links,
+> however, all future projects should use [`fluvio-smartmodule-template`][1] instead.
+
+[1]: https://github.com/infinyon/fluvio-smartmodule-template
+
 This repository is a [`cargo-generate`] template for getting started
 with writing Fluvio SmartStreams. To use it, run the following:
 


### PR DESCRIPTION
Due to the renaming of `SmartStreams` to `SmartModules`, we should archive this repository and continue future development on https://github.com/infinyon/fluvio-smartmodule-template. This PR adds a notice to the README of this repository so that future readers will know where to look in the future, then we should archive this repo.

See https://github.com/infinyon/fluvio/issues/1934#issuecomment-975800101