### PR TITLE
Include serde and serde_json by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,8 @@ crate-type = ['cdylib']
 
 [dependencies]
 fluvio-smartmodule = { version = "0.1" }
-{% if smartmodule-type == "array-map" %}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-{% endif %}
 
 # We can make this crate have its own workspace.
 # This is needed to enable `profile.relesae.lto` below.


### PR DESCRIPTION
Most of the examples, guides, and blogs that we've written that refer to this template all use serde and serde_json. In this PR I've updated the default dependencies of the project to include them so we can shorten our writing by omitting repetitive steps for adding dependencies.